### PR TITLE
Prevent -Wdelete-non-virtual-dtor

### DIFF
--- a/SoftwareSerial.h
+++ b/SoftwareSerial.h
@@ -117,7 +117,7 @@ private:
 public:
   // public methods
   SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverse_logic = false);
-  ~SoftwareSerial();
+  virtual ~SoftwareSerial();
   void begin(long speed);
   bool listen();
   void end();


### PR DESCRIPTION
Prevent 'delete-non-virtual-dtor' compiler warning when trying to deallocate SoftwareSerial object by applying 'delete' operator.