### PR TITLE
Linker error fix for non optimized build

### DIFF
--- a/SoftwareSerial.cpp
+++ b/SoftwareSerial.cpp
@@ -403,7 +403,7 @@ inline void SoftwareSerial::tunedDelay(uint16_t delay) {
     "cpi %A0, 0xFF \n\t"
     "cpc %B0, %1 \n\t"
     "brne .-10 \n\t"
-    : "+r" (delay), "+a" (tmp)
+    : "+w" (delay), "+a" (tmp)
     : "0" (delay)
     );
 }

--- a/SoftwareSerial.h
+++ b/SoftwareSerial.h
@@ -123,12 +123,12 @@ public:
   void end();
   bool isListening() { return this == active_object; }
   bool overflow() { bool ret = _buffer_overflow; _buffer_overflow = false; return ret; }
-  int peek();
+  int peek() override;
 
-  virtual size_t write(uint8_t byte);
-  virtual int read();
-  virtual int available();
-  virtual void flush();
+  virtual size_t write(uint8_t byte) override;
+  virtual int read() override;
+  virtual int available() override;
+  virtual void flush() override;
   
   using Print::write;
 


### PR DESCRIPTION
Fixes to issues #13 and #14. Compiles just fine, static code check passed. NOT UNIT TESTED. NOT TESTED ON TARGET. NOT INTEGRATION TESTED.