### PR TITLE
use AND operator to perform mod

### DIFF
--- a/SoftwareSerial.cpp
+++ b/SoftwareSerial.cpp
@@ -387,6 +387,9 @@ inline void DebugPulse(uint8_t pin, uint8_t count)
     *pport = val | digitalPinToBitMask(pin);
     *pport = val;
   }
+#else
+  (void) pin;
+  (void) count;
 #endif
 }
 
@@ -478,11 +481,11 @@ void SoftwareSerial::recv()
       d = ~d;
 
     // if buffer full, set the overflow flag and return
-    if ((_receive_buffer_tail + 1) % _SS_MAX_RX_BUFF != _receive_buffer_head) 
+    if ( ( (_receive_buffer_tail + 1) & _SS_MAX_RX_BUFF_MASK ) != _receive_buffer_head) 
     {
       // save new data in buffer: tail points to where byte goes
       _receive_buffer[_receive_buffer_tail] = d; // save new byte
-      _receive_buffer_tail = (_receive_buffer_tail + 1) % _SS_MAX_RX_BUFF;
+      _receive_buffer_tail = (_receive_buffer_tail + 1) & _SS_MAX_RX_BUFF_MASK;
     } 
     else 
     {
@@ -665,7 +668,7 @@ int SoftwareSerial::read()
 
   // Read from "head"
   uint8_t d = _receive_buffer[_receive_buffer_head]; // grab next byte
-  _receive_buffer_head = (_receive_buffer_head + 1) % _SS_MAX_RX_BUFF;
+  _receive_buffer_head = (_receive_buffer_head + 1) & _SS_MAX_RX_BUFF_MASK;
   return d;
 }
 
@@ -674,7 +677,7 @@ int SoftwareSerial::available()
   if (!isListening())
     return 0;
 
-  return (_receive_buffer_tail + _SS_MAX_RX_BUFF - _receive_buffer_head) % _SS_MAX_RX_BUFF;
+  return (_receive_buffer_tail + _SS_MAX_RX_BUFF - _receive_buffer_head) & _SS_MAX_RX_BUFF_MASK;
 }
 
 size_t SoftwareSerial::write(uint8_t b)

--- a/SoftwareSerial.h
+++ b/SoftwareSerial.h
@@ -40,10 +40,18 @@ http://arduiniana.org.
 * Definitions
 ******************************************************************************/
 
-#define _SS_MAX_RX_BUFF 64 // RX buffer size
 #ifndef GCC_VERSION
 #define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #endif
+
+constexpr bool is_powerof2(int v) {
+    return v && ((v & (v - 1)) == 0);
+}
+
+const unsigned int _SS_MAX_RX_BUFF       = 64u;                  // RX buffer size
+const unsigned int _SS_MAX_RX_BUFF_MASK  = (_SS_MAX_RX_BUFF - 1u); // mask for buffer size
+
+static_assert(is_powerof2(_SS_MAX_RX_BUFF), "Max RX buffer should be a power of 2.");
 
 #if defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MKL26Z64__) || defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__IMXRT1052__) || defined(__IMXRT1062__)
 


### PR DESCRIPTION
Hallo,
first of all thanks for this library.

Since the max size of the  _RX_ buffer is a power of two, it might be convinient to use the `&`-operator:
I found that, for example, `avr-gcc (GCC) 7.3.0` does not optimize it, but use the expensive `_divmodhi` to perform `n % 64`.